### PR TITLE
Adding support for 'isnt' control word

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -146,7 +146,7 @@
     'name': 'string.regexp.livescript'
   }
   {
-    'match': '(?x)\n\t\t\t\t\\b(?<![\\.\\$\\-])(?:\n\t\t        t(?:h(?:is|row|en)|ry|ypeof!?|il|o)\n\t\t        |c(?:on(?:tinue|st)|a(?:se|tch)|lass)\n\t\t        |i(?:n(?:stanceof)?|mp(?:ort(?:\\s+all)?|lements)|[fs])\n\t\t        |d(?:e(?:fault|lete|bugger)|o)\n\t\t        |f(?:or(?:\\s+own)?|inally|unction|rom|allthrough)\n\t\t        |s(?:uper|witch)\n\t\t        |e(?:lse|x(?:tends|port)|val)\n\t\t        |a(?:nd|rguments)\n\t\t        |n(?:ew|ot)\n\t\t        |un(?:less|til)\n\t\t        |w(?:hile|ith|hen)\n\t\t        |o(?:f|r|therwise)\n\t\t        |return|break|let|var|loop\n\t\t        |match\n\t\t        |by\n\t\t\t\t)(?!\\-|\\s*:)\\b\n\t\t\t'
+    'match': '(?x)\n\t\t\t\t\\b(?<![\\.\\$\\-])(?:\n\t\t        t(?:h(?:is|row|en)|ry|ypeof!?|il|o)\n\t\t        |c(?:on(?:tinue|st)|a(?:se|tch)|lass)\n\t\t        |i(?:n(?:stanceof)?|mp(?:ort(?:\\s+all)?|lements)|snt|[fs])\n\t\t        |d(?:e(?:fault|lete|bugger)|o)\n\t\t        |f(?:or(?:\\s+own)?|inally|unction|rom|allthrough)\n\t\t        |s(?:uper|witch)\n\t\t        |e(?:lse|x(?:tends|port)|val)\n\t\t        |a(?:nd|rguments)\n\t\t        |n(?:ew|ot)\n\t\t        |un(?:less|til)\n\t\t        |w(?:hile|ith|hen)\n\t\t        |o(?:f|r|therwise)\n\t\t        |return|break|let|var|loop\n\t\t        |match\n\t\t        |by\n\t\t\t\t)(?!\\-|\\s*:)\\b\n\t\t\t'
     'name': 'keyword.control.livescript'
   }
   {


### PR DESCRIPTION
At the same level that `is` or `not`.
Details: http://livescript.net/#operators-comparison.

![captura de pantalla 2016-06-07 a las 12 24 40](https://cloud.githubusercontent.com/assets/1742635/15854572/def9b1ca-2caa-11e6-92a3-2c94d2706139.png)
